### PR TITLE
Added GitHub action and some unit-tests

### DIFF
--- a/.github/workflows/prolog.yaml
+++ b/.github/workflows/prolog.yaml
@@ -1,0 +1,49 @@
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: prolog_pack
+ 
+jobs:
+  run-tests:
+    runs-on: ${{ matrix.os }}-latest
+    name: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install R
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt update
+          sudo apt install -y r-base
+          sudo apt install -y r-base libtirpc-dev
+          mkdir -p $HOME/Rlibs 
+          R -e "install.packages('RInside', lib='$HOME/Rlibs'); install.packages('Rcpp', lib='$HOME/Rlibs')"
+          echo "R_LIBS=$HOME/Rlibs" >> ~/.Renviron
+          R -e "library(RInside); library(Rcpp)"
+          echo "R_LIBS_USER=$HOME/Rlibs" >> $GITHUB_ENV
+          
+      - name: Install SWI-Prolog on Linux
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-add-repository ppa:swi-prolog/devel
+          sudo apt-get update
+          sudo apt-get install swi-prolog
+        shell: bash
+
+      - name: Check installation
+        run: swipl -t check_installation
+        shell: bash
+
+      - name: Install rolog pack
+        run: |
+          export R_LIBS_USER=$HOME/Rlibs
+          swipl -t "pack_install(rolog, [interactive(false)])"
+        shell: bash
+
+

--- a/prolog/rolog.pl
+++ b/prolog/rolog.pl
@@ -45,7 +45,7 @@ pl2r_(A[B], X)
  => pl2r_('['(A, B), X).
 
 pl2r_({}, X)
- => X = 'NULL'.
+ => X = [].
  
 pl2r_({A; B}, X)
  => pl2r_curly({A; B}, C),

--- a/test/test_rolog.pl
+++ b/test/test_rolog.pl
@@ -7,12 +7,68 @@
 :- use_module(library(rolog)).
 
 test_rolog :-
-    run_tests([rolog]).
+    run_tests([basic, assignment, vector, indexing]).
 
-:- begin_tests(rolog).
+:- begin_tests(basic).
 
 test(basic) :-
     r_eval(2 + 2, Res),
     assertion(Res =@= 4).
 
-:- end_tests(rolog).
+test(comparison1) :-
+    r_eval(2 =< 3, Res),
+    assertion(Res =@= true).
+
+:- end_tests(basic).
+
+:- begin_tests(assignment).
+
+test(assignment1) :-
+    r_call(v <- 1),
+    r_eval(v, Res),
+    assertion(Res =@= 1).
+
+:- end_tests(assignment).
+
+:- begin_tests(vector).
+
+test(integer_vector) :-
+    r_call(v <- #(1:5)),
+    r_eval(v, Res),
+    Res1 = '%%'(1, 2, 3, 4, 5),
+    assertion(Res =@= Res1).
+
+test(float_vector) :-
+    r_call(v <- #(1.1:5.1)),
+    r_eval(v, Res),
+    Res1 = ##(1.1, 2.1, 3.1, 4.1, 5.1),
+    assertion(Res =@= Res1).
+
+test(char_vector) :-
+    r_call(v <- #("foo", "bar")),
+    r_eval(v, Res),
+    Res1 = $$("foo", "bar"),
+    assertion(Res =@= Res1).
+
+test(boolean_vector) :-
+    r_call(v <- #(true, false)),
+    r_eval(v, Res),
+    Res1 = '!!'(true, false),
+    assertion(Res =@= Res1).
+
+:- end_tests(vector).
+
+:- begin_tests(indexing).
+
+test(indexing1) :-
+    r_call(v <- #(1:5)),
+    r_eval(v[3], Res),
+    assertion(Res =@= 3).
+
+:- end_tests(indexing).
+
+%fails
+/* test(empty_brackets) :-
+    r_eval({}, Res),
+    assertion(Res =@= 'NULL'). */
+

--- a/test/test_rolog.pl
+++ b/test/test_rolog.pl
@@ -7,7 +7,7 @@
 :- use_module(library(rolog)).
 
 test_rolog :-
-    run_tests([basic, assignment, vector, indexing]).
+    run_tests([basic, assignment, vector, indexing, empty]).
 
 :- begin_tests(basic).
 
@@ -67,8 +67,10 @@ test(indexing1) :-
 
 :- end_tests(indexing).
 
-%fails
-/* test(empty_brackets) :-
-    r_eval({}, Res),
-    assertion(Res =@= 'NULL'). */
+:- begin_tests(empty).
 
+test(empty_brackets) :-
+    r_eval({}, Res),
+    assertion(Res =@= []).
+
+:- end_tests(empty).


### PR DESCRIPTION
I also tried to add this test, but it fails:

```
test(empty_brackets) :-
    r_eval({}, Res),
    assertion(Res =@= 'NULL').
```

```
?- r_eval({}, Res).
Error: object 'NULL' not found
terminate called after throwing an instance of 'Rcpp::LongjumpException'
Aborted
```

I deduced this test case from these lines:
```
pl2r_({}, X)
 => X = 'NULL'.
```

Is this needed for something else, so that it will never happen that {} will appear as input?
